### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # iOS Simulator MCP Server
+[![smithery badge](https://smithery.ai/badge/@joshuarileydev/simulator-mcp-server)](https://smithery.ai/server/@joshuarileydev/simulator-mcp-server)
 
 A Model Context Protocol (MCP) server that provides programmatic control over iOS simulators. This server implements the MCP specification to expose simulator functionality through a standardized interface.
 
@@ -10,6 +11,16 @@ A Model Context Protocol (MCP) server that provides programmatic control over iO
 - Launch installed apps by bundle ID
 
 ## Installation
+
+### Installing via Smithery
+
+To install iOS Simulator Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@joshuarileydev/simulator-mcp-server):
+
+```bash
+npx -y @smithery/cli install @joshuarileydev/simulator-mcp-server --client claude
+```
+
+### Installing Manually
 Add the following to your Claude Config JSON file
 ```
 {


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install iOS Simulator Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@joshuarileydev/simulator-mcp-server

Let me know if any tweaks have to be made!